### PR TITLE
Heya: Shorten description and move explanation to content

### DIFF
--- a/_projects/heya.md
+++ b/_projects/heya.md
@@ -1,6 +1,6 @@
 ---
 title: Heya
-description: a campaign mailer for Ruby on Rails. It's like ActionMailer, but for timed email sequences. It can also perform other actions like sending a text message.
+description: a campaign mailer for Ruby on Rails
 repository: https://github.com/honeybadger-io/heya
 language: Ruby
 developer:
@@ -10,3 +10,5 @@ version: 3.0.0
 layout: project
 date: 2020-04-16
 ---
+
+Heya is like ActionMailer, but for timed email sequences. It can also perform other actions like sending a text message.


### PR DESCRIPTION
@joshuap, this PR splits the description for Heya that you added between the description and the content of the file. That way Heya appears like other projects on the homepage, and your explanation still appears on Heya's page.